### PR TITLE
Docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,11 @@ add_executable(monitor EXCLUDE_FROM_ALL test/monitor.cpp test/test_util.c src/sp
 target_link_libraries(monitor spiproto pthread)
 target_include_directories(monitor PUBLIC src/ PUBLIC test/)
 
-#TODO can only run on linux
-#click-test: test/click-test.cpp libspiproto.a spi_chunks.o test/test_util.o spi_proto_util.o
-#	#g++ $(CFLAGS) -o click-test test/click-test.cpp -std=c++14 -pthread spi_chunks.o test/test_util.o spi_proto_util.o -L. -lspiproto -I. -Isrc
-#	g++ test/click-test.cpp src/spi_proto_master.cpp src/spi_chunks.cpp -std=c++14 -pthread -x c src/binary_semaphore.c -x c src/spi_proto.c -I. -Isrc/ -x c src/crc16.c -x c src/spi_remote_host.c -o click-test -g
+#these two can only be built on linux
+add_executable(click-test EXCLUDE_FROM_ALL test/click-test.cpp src/spi_proto_master.cpp src/spi_chunks.cpp src/binary_semaphore.c src/spi_proto.c src/crc16.c src/spi_remote_host.c)
+target_link_libraries(click-test spiproto pthread)
+target_include_directories(click-test PUBLIC src/ PUBLIC test/)
 
-#TODO can only run on linux
-#blip-test: test/blip-test.cpp libspiproto.a spi_chunks.o test/test_util.o spi_proto_util.o
-#	#g++ $(CFLAGS) -o blip-test test/blip-test.cpp -std=c++14 -pthread spi_chunks.o test/test_util.o spi_proto_util.o -L. -lspiproto -I. -Isrc
-#	g++ test/blip-test.cpp src/spi_proto_master_datagram.cpp src/spi_chunks.cpp -std=c++14 -pthread -x c src/binary_semaphore.c -x c src/spi_proto.c -I. -Isrc/ -x c src/crc16.c -x c src/spi_remote_host.c -o blip-test -g
+add_executable(blip-test test/blip-test.cpp src/spi_proto_master_datagram.cpp src/spi_chunks.cpp src/binary_semaphore.c src/spi_proto.c src/crc16.c src/spi_remote_host.c)
+target_link_libraries(blip-test spiproto pthread)
+target_include_directories(blip-test PUBLIC src/ PUBLIC test/)

--- a/datagram.md
+++ b/datagram.md
@@ -15,6 +15,11 @@ It requires `heartrateLED.elf` from the `amm-tiny` repo to be on the k66f.
 * -2 if no space available to send message
 
 The `spi_callback` variable is a callback for received messages.
+
+    extern void (*spi_callback)(struct spi_packet*);
+
+This function receives the protocol information as well as payload, which is in field `msg` of the argument.
+`msg` is declared `uint8_t msg[SPI_MSG_PAYLOAD_LEN];`.
 If you do not need to receive messages, it can be `NULL` but it must be present.
 
 `void datagram_task(void)` should be called as a thread, e.g. `std::thread thread(datagram_task);`, and must be running before `send_message` is called.

--- a/datagram.md
+++ b/datagram.md
@@ -4,6 +4,7 @@ Unlike the remote api with its many functions, this has only two, send and recei
 You must write a custom program running on the AMMDK k66f to make any practical use of this functionality.
 
 `test/blip-test.cpp` is an example of a program that uses this API.
+It requires `heartrateLED.elf` from the `amm-tiny` repo to be on the k66f.
 
 ## Functions
 
@@ -13,6 +14,7 @@ You must write a custom program running on the AMMDK k66f to make any practical 
 * -1 if `len` > `SPI_MSG_PAYLOAD_LEN`
 * -2 if no space available to send message
 
-`TODO` is a callback for received messages.
+The `spi_callback` variable is a callback for received messages.
+If you do not need to receive messages, it can be `NULL` but it must be present.
 
 `void datagram_task(void)` should be called as a thread, like `std::thread thread(datagram_task);` and must be running before `send_message` is called.

--- a/datagram.md
+++ b/datagram.md
@@ -3,7 +3,7 @@
 Unlike the remote api with its many functions, this has only two, send and receive a message.
 You must write a custom program running on the AMMDK k66f to make any practical use of this functionality.
 
-`test/blip-test.cpp` is an example of a program that uses this API.
+[`test/blip-test.cpp`] is an example of a program that uses this API.
 It requires `heartrateLED.elf` from the `amm-tiny` repo to be on the k66f.
 
 ## Functions

--- a/datagram.md
+++ b/datagram.md
@@ -17,4 +17,4 @@ It requires `heartrateLED.elf` from the `amm-tiny` repo to be on the k66f.
 The `spi_callback` variable is a callback for received messages.
 If you do not need to receive messages, it can be `NULL` but it must be present.
 
-`void datagram_task(void)` should be called as a thread, like `std::thread thread(datagram_task);` and must be running before `send_message` is called.
+`void datagram_task(void)` should be called as a thread, e.g. `std::thread thread(datagram_task);`, and must be running before `send_message` is called.

--- a/readme.md
+++ b/readme.md
@@ -3,15 +3,80 @@
 ## Purpose
 
 The ability to control the Tiny peripherals and access DDS messages from a single program greatly simplifies writing such programs.
+For an example of direct usage, see the [datagram documentation.](datagram.md)
+
+## Usage
+
+Include the following header:
+
+    #include "spi_remote.h"
+
+You must put the file `99-spidev-open.rules` into `/etc/udev/rules.d` and either reboot or run `udevadm control --reload-rules`.
+This will allow non-privileged users (specifically the `amm` user) to access the spi interface.
+
+### Function usage
+
+`void remote_set_gpio(int ix, int val)`
+
+Set gpio number `ix` to `val`.
+Blocking.
+
+`void remote_set_gpio_meta(int ix, int val)`
+
+Set direction of gpio number `ix`.
+Blocking.
+See [spi_chunk_defines.h](src/spi_chunk_defines.h) for parameter meanings.
+
+`bool remote_get_gpio(int ix)`
+
+Get the input of gpio number `ix`.
+Blocking.
+You should first set the direction of the gpio with `remote_set_gpio_meta`.
+
+`void remote_set_dac(int ix, int val)`
+
+Set DAC number `ix` to `val`.
+Clamped between 0x000 and 0xfff.
+Blocking.
+
+`uint32_t remote_get_adc(int ix)`
+
+Return the current ADC reading. It is only refreshed at 50Hz.
+The maximum value is 4095 (12 bits, 0x000 to 0xfff).
+
+`void remote_task(void);`
+
+Create a thread as `std::thread remote_thread(remote_task);` to use this API.
+This thread sits in a loop, summarized below:
+
+    forever:
+        msg = queued_messages();
+        response = spi_send(msg);
+        process(response);
+
+#### Internal
+
+`int send_chunk(uint8_t *buf, size_t len);`
+
+This is used by all functions to enqueue messages to be packed to be sent over the SPI connection.
+The first byte of `buf` is overwritten with `len`.
+
+## Example
+
+[`test/click-test.cpp`](test/click-test.cpp) is a simple example.
 
 ## How it works
 
-There is another thread, `remote_thread`, which handles sending and receiving all SPI messages. The application can send length-prefixed chunks to this thread, which are then greedily packed into the next outgoing message. The remote thread signals the controlling thread through semaphores in a struct `remote` linked in in `spi_proto_master.cpp`. On the tiny there is a function which dispatches several kinds of chunks. The flow for using a peripheral is as follows:
+There is another thread, `remote_thread`, which handles sending and receiving all SPI messages.
+The application can send length-prefixed chunks to this thread, which are then greedily packed into the next outgoing message.
+The remote thread signals the controlling thread through semaphores in a struct `remote` linked in in `spi_proto_master.cpp`.
+On the tiny there is a function which dispatches several kinds of chunks.
+The flow for using a peripheral is as follows:
 
 [where]  
 
 1. [app] Send a chunk with a command for that peripheral
-2. [app] Wait and block on the sempahore for that peripheral.
+2. [app] Wait and block on the semaphore for that peripheral.
 3. [remote] Send the chunk.
 4. [tiny] Receive chunk, perform action, and send confirmation chunk.
 5. [remote] Receive chunk and dispatch, storing any return value and signaling on the appropriate semaphore.
@@ -23,57 +88,23 @@ The remote thread sends and receives messages at about 1kHz.
 
 ### Internal details
 
-A struct of lists of semaphores is at global scope. This struct has one semaphore for each peripheral. This allows the `remote_*` api calls to block and appear to the user as though they are directly manipulating peripherals. This abstraction has the flaw that all calls block. It would be possible to hold semaphores only until the chunk has been properly sent (using internal knowledge of the protocol) but this is not a guarantee that the requested action has been taken. This idea was not used because it will only save time in a few unusual cases with very specific message retransmit patterns. The confirmation message is usually transmitted in the round immediately after the command message.
+A struct of lists of semaphores is at global scope.
+This struct has one semaphore for each peripheral.
+This allows the `remote_*` api calls to block and appear to the user as though they are directly manipulating peripherals.
+This abstraction has the flaw that all calls block.
+It would be possible to hold semaphores only until the chunk has been properly sent (using internal knowledge of the protocol) but this is not a guarantee that the requested action has been taken.
+This idea was not used because it will only save time in a few unusual cases with very specific message retransmit patterns.
+The confirmation message is usually transmitted in the round immediately after the command message.
 
 ## Caveats
 
-The provided functions wait for each command to be confirmed before sending the next. It is possible to send all commands and then wait for each to complete. This will save some time but is not really necessary, although it might be useful for synchronizing valves more closely.
+The provided functions wait for each command to be confirmed before sending the next.
+It is possible to send all commands and then wait for each to complete.
+This will save some time but is not really necessary, although it might be useful for synchronizing valves more closely.
 
 ## Bugs
 
-The semaphores used are not queueing semaphores, so it's possible that if two threads issue read commands at very close times they will read one another's return value. This is not a serious concern: It requires two threads that are using overlapping subsets of the peripherals. It's hard to say that any control system overlapping with another will give good results. Further both threads will usually read the same value.
-
-## Usage
-
-Include the following header:
-
-    #include "spi_remote.h"
-
-You must put the file `99-spidev-open.rules` into `/etc/udev/rules.d` and either reboot or run `udevadm control --reload-rules`
-
-### Function usage
-
-`void remote_set_gpio(int ix, int val)`
-
-Set gpio number `ix` to `val`. Blocking.
-
-`bool remote_get_gpio(int ix)`
-
-Get the input of gpio number `ix`. Blocking. Requires you be able to set the modes of a gpio, which is pending.
-
-`void remote_set_dac(int ix, int val)`
-
-Set DAC number `ix` to `val`. Clamped between 0x000 and 0xfff. Blocking.
-
-`uint32_t remote_get_adc(int ix)`
-
-Return the current ADC reading. It is only refreshed at 50Hz. The maximum value is TODO MAX.
-
-`void remote_task(void);`
-
-Create a thread as `std::thread remote_thread(remote_task);` to use this API. This thread sits in a loop, summarized below:
-
-    forever:
-        msg = queued_messages();
-        response = spi_send(msg);
-        process(response);
-
-#### Internal
-
-`int send_chunk(uint8_t *buf, size_t len);`
-
-This is used by all functions to enqueue messages to be packed to be sent over the SPI connection. The first byte of `buf` is overwritten with `len`.
-
-## example
-
-`test/click-test.cpp` is a simple example.
+The semaphores used are not queueing semaphores, so it's possible that if two threads issue read commands at very close times they will read one another's return value.
+This is not a serious concern: It requires two threads that are using overlapping subsets of the peripherals.
+It's hard to say that any control system overlapping with another will give good results.
+Further both threads will usually read the same value.

--- a/readme.md
+++ b/readme.md
@@ -21,17 +21,18 @@ This will allow non-privileged users (specifically the `amm` user) to access the
 Set gpio number `ix` to `val`.
 Blocking.
 
-`void remote_set_gpio_meta(int ix, int val)`
-
-Set direction of gpio number `ix`.
-Blocking.
-See [spi_chunk_defines.h](src/spi_chunk_defines.h) for parameter meanings.
-
 `bool remote_get_gpio(int ix)`
 
 Get the input of gpio number `ix`.
 Blocking.
 You should first set the direction of the gpio with `remote_set_gpio_meta`.
+
+`void remote_set_gpio_meta(int ix, int val)`
+
+Set direction of gpio number `ix` to `val`.
+Blocking.
+`val` is either `OP_SET` or `OP_GET` (defined in [spi_chunk_defines.h](src/spi_chunk_defines.h)).
+GPIO default to `OP_SET`.
 
 `void remote_set_dac(int ix, int val)`
 
@@ -70,7 +71,7 @@ The first byte of `buf` is overwritten with `len`.
 There is another thread, `remote_thread`, which handles sending and receiving all SPI messages.
 The application can send length-prefixed chunks to this thread, which are then greedily packed into the next outgoing message.
 The remote thread signals the controlling thread through semaphores in a struct `remote` linked in in `spi_proto_master.cpp`.
-On the tiny there is a function which dispatches several kinds of chunks.
+On the k66f there is a function which dispatches several kinds of chunks.
 The flow for using a peripheral is as follows:
 
 [where]  
@@ -78,7 +79,7 @@ The flow for using a peripheral is as follows:
 1. [app] Send a chunk with a command for that peripheral
 2. [app] Wait and block on the semaphore for that peripheral.
 3. [remote] Send the chunk.
-4. [tiny] Receive chunk, perform action, and send confirmation chunk.
+4. [k66f] Receive chunk, perform action, and send confirmation chunk.
 5. [remote] Receive chunk and dispatch, storing any return value and signaling on the appropriate semaphore.
 6. [app] Return from semaphore and take return value, if any.
 

--- a/test/blip-test.cpp
+++ b/test/blip-test.cpp
@@ -1,5 +1,5 @@
-//g++ click-test.cpp spi_proto_master.cpp spi_proto_lib/spi_chunks.cpp -std=c++14 -pthread -x c binary_semaphore.c -x c spi_proto_lib/spi_proto.c -I. -Ispi_proto_lib/ -x c crc16.c -x c spi_remote_host.c -o click -g
 //causes solenoids to click in strobing sequence. Remote API test
+//use with HeartrateLED k66f code.
 #include <thread>
 #include "spi_datagram.h"
 
@@ -19,7 +19,12 @@ dummy_callback(struct spi_packet *p)
   /* If we linked with this function and the k66f code simply echoed our
    * messages, this would receive arguments where p->msg[0] was alternately 60
    * and 120.
+   * Here we print out the received bytes in hex.
    */
+  for (int i = 0; i < sizeof(struct spi_packet); i++) {
+    printf("%02x ", ((unsigned char *)p)[i]);
+  }
+  puts("");
 }
 void (*spi_callback)(struct spi_packet *p) = dummy_callback;
 

--- a/test/blip-test.cpp
+++ b/test/blip-test.cpp
@@ -7,21 +7,35 @@ using namespace spi_proto;
 
 void
 blip_task(void);
-void (*spi_callback)(struct spi_packet *p) = NULL;
+/* We need to declare a function pointer, the library expects to be linked with
+ * one. It's not necessary that it be an actual function.
+ *
+ * This would also be fine:
+ * void (*spi_callback)(struct spi_packet *p) = NULL;
+ */
+void
+dummy_callback(struct spi_packet *p)
+{
+  /* If we linked with this function and the k66f code simply echoed our
+   * messages, this would receive arguments where p->msg[0] was alternately 60
+   * and 120.
+   */
+}
+void (*spi_callback)(struct spi_packet *p) = dummy_callback;
 
 int main(int argc, char *argv[]) {
 	std::thread remote_thread(datagram_task);
 	std::thread click_thread(blip_task);
-	
+
 	while (1) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
-	
+
 	return 0;
-	
+
 }
 
-//functions implemented for port
+//helper function, not related to remote api
 void
 delay_ms(unsigned int ms)
 {

--- a/test/blip-test.cpp
+++ b/test/blip-test.cpp
@@ -7,6 +7,7 @@ using namespace spi_proto;
 
 void
 blip_task(void);
+
 /* We need to declare a function pointer, the library expects to be linked with
  * one. It's not necessary that it be an actual function.
  *

--- a/test/click-test.cpp
+++ b/test/click-test.cpp
@@ -9,19 +9,21 @@ void
 click_task(void);
 
 int main(int argc, char *argv[]) {
+  /* Boilerplate. Start the SPI communication thread after initializing the
+   * shared data structure. Then start the task thread.
+   */
 	host_remote_init(&remote);
 	std::thread remote_thread(remote_task);
 	std::thread click_thread(click_task);
-	
+
 	while (1) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
-	
+
 	return 0;
-	
 }
 
-//functions implemented for port
+//just a helper function
 void
 delay_ms(unsigned int ms)
 {
@@ -31,16 +33,16 @@ delay_ms(unsigned int ms)
 void
 click_task(void)
 {
-	//enable 24V rail
 	puts("enabling 24V!");
-	remote_set_gpio(15, 1); //15 is 24V rail
-	
-	
-	//module logic:
-	//wait for start message
-	//begin pressurizing
-	//when pressurized, stop pressurizing and send the "I'm sealed" message to SoM code
+  /* 15 is the 24V rail on the AMMDK V1. We know this by comparing the table in
+   * amm-tiny/source/ammdk-carrier/carrier_gpio.cpp to the AMMDK V1 spreadsheet.
+   */
+	remote_set_gpio(15, 1);
+
 	int wait = 200;
+  /* Again, this number arrived at by comparing the carrier_gpio.cpp table with
+   * the spreadsheet.
+   */
 	uint8_t solenoid_0 = 7;
 	puts("starting clicking!");
 	for (;;) {


### PR DESCRIPTION
#3 readme.md improvements

- [x]  Move 'Usage' section up so it's after 'Purpose', and also update it with info for remote_get_gpio (and anything else in this section if appropriate).
- [x]  Also explain that the udev thing is for device access.
- [x]  Add brief description plus a link to datagram.md for that API in contrast to remote API.

#4 click-test.cpp improvements

- [x]  Add comments for the boilerplate on lines 12-14.
- [x]  Add a description of the process of figuring out what the magic numbers for the GPIO pins are. E.g. cross-reference blah & blah from the K66 data sheet to figure out which number for which K66 pin.

#5 datagram.md improvements

- [x]  Fix TODO about callback. Explain or link an example of what must be on the K66 side to use this API.
- [ ]  Preferably there's also a design doc in the tiny repo w/ a description & link to example (heartrateLED?).

#6 blip-test.cpp improvements

- [x]  Comment spi_callback declaration on line 10.
- [x]  Implement example callback, maybe assuming the K66 code is just echoing SPI messages?
- [ ]  This should link to the k66f code it needs to work.
- [x]  confirm that it compiles with cmake and remove compilaiton instructions in the top line of the file.

Only remaining are 5 and 6, 6 is there but just a mention and 5 is a task for tiny